### PR TITLE
Make docker-compose-updater not recurse below folders containing docker-compose-versions.yml

### DIFF
--- a/docker-compose-updater/src/docker_compose_update.py
+++ b/docker-compose-updater/src/docker_compose_update.py
@@ -556,6 +556,22 @@ def write_email(msg_text, msg_subject):
         )
 
 
+def get_docker_compose_directories(base_path):
+    """ Get and interator over all directories containing
+    docker-compose-versions.yml files. This does not recurse below a folder
+    that has already been found.
+    :return: Iterator over found directories
+    """
+    subentries = os.listdir(base_path)
+    if "docker-compose-versions.yml" in subentries:
+        yield os.path.join(base_path)
+        return
+    for subpath in subentries:
+        path = os.path.join(base_path, subpath)
+        if os.path.isdir(path):
+            yield from get_docker_compose_directories(path)
+
+
 def main():
     """Entrypoint when used as an executable
     :returns: None
@@ -578,11 +594,7 @@ def main():
             sys.exit(0)
         # If the recursive option is given, recursiveley search for
         # docker-compose-versions.yml and run the updater for each found path
-        pathlist = []
-        for root, _, files in os.walk(args.path):
-            for file in files:
-                if file == "docker-compose-versions.yml":
-                    pathlist.append(root)
+        pathlist = list(get_docker_compose_directories(args.path))
         if not pathlist:
             text = "No docker-compose-versions.yml files where found in the given path"
             logging.warning(text)

--- a/docker-compose-updater/src/test/example_services/docker_compose_versions_in_subdir/docker-compose-versions.yml
+++ b/docker-compose-updater/src/test/example_services/docker_compose_versions_in_subdir/docker-compose-versions.yml
@@ -1,0 +1,4 @@
+manual_update:
+  dummy: 3\.[0-9]+\.[0-9]+
+auto_update:
+  dummy: 3\.[0-9]+\.[0-9]+

--- a/docker-compose-updater/src/test/example_services/docker_compose_versions_in_subdir/subdir/docker-compose-versions.yml
+++ b/docker-compose-updater/src/test/example_services/docker_compose_versions_in_subdir/subdir/docker-compose-versions.yml
@@ -1,0 +1,4 @@
+manual_update:
+  dummy: 3\.[0-9]+\.[0-9]+
+auto_update:
+  dummy: 3\.[0-9]+\.[0-9]+

--- a/docker-compose-updater/src/test/test_docker_compose_update.py
+++ b/docker-compose-updater/src/test/test_docker_compose_update.py
@@ -10,6 +10,7 @@ import requests
 from src.docker_compose_update import Updater
 from src.docker_compose_update import Service
 from src.docker_compose_update import initialize_logging
+from src.docker_compose_update import get_docker_compose_directories
 
 
 # pylint: disable=missing-function-docstring,no-self-use
@@ -227,6 +228,31 @@ class TestDockerComposeUpdate:  # pylint: disable=missing-class-docstring
                 pass
             assert not logging_mock.getLogger().setLevel.called
             assert logging_mock.error.called
+
+    def test_get_docker_compose_directories(self):
+        directories = get_docker_compose_directories("src/test/example_services")
+        directory_list = list(directories)
+        for test_directory in [
+            "src/test/example_services/empty_versions",
+            "src/test/example_services/up_to_date",
+            "src/test/example_services/base",
+            "src/test/example_services/manual_update",
+            "src/test/example_services/dockerfile_base",
+            "src/test/example_services/manual_update_only",
+            "src/test/example_services/auto_update_only",
+            "src/test/example_services/key_error",
+            "src/test/example_services/docker_compose_empty",
+            "src/test/example_services/dockerfile_empty",
+            "src/test/example_services/no_init_version",
+            "src/test/example_services/yaml_error_in_versions",
+            "src/test/example_services/docker_compose_versions_in_subdir",
+        ]:
+            assert test_directory in directory_list
+        assert "src/test/example_services/empty_dir" not in directory_list
+        assert (
+            "src/test/example_services/docker_compose_versions_in_subdir/subdir"
+            not in directory_list
+        )
 
 
 def request_dockerhub(status_code):


### PR DESCRIPTION
Make docker-compose-updater not recurse below folders containing
docker-compose-versions.yml
Fixes #14